### PR TITLE
MNT: Update feedstock recipe for modern noarch python

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,8 +1,16 @@
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_min:
+- '3.9'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jakirkham @nicoddemus
+* @jakirkham @matthewfeickert @nicoddemus @ofek

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Package license: Apache-2.0
 
 Summary: Core utilities for Python packages
 
+Development: https://github.com/pypa/packaging
+
+Documentation: https://packaging.pypa.io/
+
 Current build status
 ====================
 
@@ -144,5 +148,7 @@ Feedstock Maintainers
 =====================
 
 * [@jakirkham](https://github.com/jakirkham/)
+* [@matthewfeickert](https://github.com/matthewfeickert/)
 * [@nicoddemus](https://github.com/nicoddemus/)
+* [@ofek](https://github.com/ofek/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,30 @@
 {% set version = "24.2" %}
+{% set python_min = "3.8" %}
 
 package:
   name: packaging
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/packaging/packaging-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/packaging/packaging-{{ version }}.tar.gz
   sha256: c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.8
+    - python {{ python_min }}
     - flit >=3.3
     - pip
-
   run:
-    - python >=3.8
+    - python >={{ python_min }}
 
 test:
   requires:
+    - python {{ python_min }}
     - pip
   imports:
     - packaging
@@ -35,8 +36,12 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   summary: Core utilities for Python packages
+  doc_url: https://packaging.pypa.io/
+  dev_url: https://github.com/pypa/packaging
 
 extra:
   recipe-maintainers:
     - jakirkham
     - nicoddemus
+    - matthewfeickert
+    - ofek


### PR DESCRIPTION
* Use `python {{ python_min }}` syntax for the python requirements for noarch python recipes.
   - c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python
* Use a Jinja2 `set` statement for the `python_min` to allow all the build metadata to be contained in the `recipe/meta.yaml` and override the global `python_min` with `packaging`'s `python_min` of `3.8`.
* Remove `--no-deps` as the build tool (e.g. `conda-build`, `rattler-build`) will specify all required `pip install` options.
   - c.f. https://github.com/conda/grayskull/issues/582
* Use 'pypi.org'.
* Add @matthewfeickert and @ofek as feedstock maintainers.
   - c.f. https://github.com/conda-forge/packaging-feedstock/pull/31#issuecomment-2472019764
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
